### PR TITLE
Added -b flag for pretty-bytes output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
-
 'use strict';
 const fs = require('fs');
 const meow = require('meow');
 const fn = require('gzip-size');
-const pb = require('pretty-bytes');
+const prettyBytes = require('pretty-bytes');
 
 const cli = meow(`
 	Usage
@@ -16,8 +15,8 @@ const cli = meow(`
 	  211
 `);
 
-const input = cli.input[0];
-const bytesFlag = cli.flags.b;
+const input = cli.input[0] || cli.flags.pretty;
+const bytesFlag = cli.flags.pretty;
 
 if (!input && process.stdin.isTTY) {
 	console.error('Specify a filename');
@@ -26,10 +25,4 @@ if (!input && process.stdin.isTTY) {
 
 const source = input ? fs.createReadStream(input) : process.stdin;
 
-source.pipe(fn.stream()).on('gzip-size', gzipSize => {
-	if (bytesFlag) {
-		console.log(pb(gzipSize));
-	} else {
-		console.log(gzipSize);
-	}
-});
+source.pipe(fn.stream()).on('gzip-size', gzipSize => bytesFlag ? console.log(prettyBytes(gzipSize)) : console.log(gzipSize));

--- a/cli.js
+++ b/cli.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
+
 'use strict';
 const fs = require('fs');
 const meow = require('meow');
 const fn = require('gzip-size');
+const pb = require('pretty-bytes');
 
 const cli = meow(`
 	Usage
@@ -15,6 +17,7 @@ const cli = meow(`
 `);
 
 const input = cli.input[0];
+const bytesFlag = cli.flags.b;
 
 if (!input && process.stdin.isTTY) {
 	console.error('Specify a filename');
@@ -23,4 +26,10 @@ if (!input && process.stdin.isTTY) {
 
 const source = input ? fs.createReadStream(input) : process.stdin;
 
-source.pipe(fn.stream()).on('gzip-size', console.log);
+source.pipe(fn.stream()).on('gzip-size', gzipSize => {
+	if (bytesFlag) {
+		console.log(pb(gzipSize));
+	} else {
+		console.log(gzipSize);
+	}
+});

--- a/cli.js
+++ b/cli.js
@@ -25,4 +25,6 @@ if (!input && process.stdin.isTTY) {
 
 const source = input ? fs.createReadStream(input) : process.stdin;
 
-source.pipe(fn.stream()).on('gzip-size', gzipSize => bytesFlag ? console.log(prettyBytes(gzipSize)) : console.log(gzipSize));
+source.pipe(fn.stream()).on('gzip-size', gzipSize => {
+	console.log(bytesFlag ? prettyBytes(gzipSize) : gzipSize);
+});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "dependencies": {
     "gzip-size": "^3.0.0",
-    "meow": "^3.7.0"
+    "meow": "^3.7.0",
+    "pretty-bytes": "^4.0.2"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const execa = require('execa');
 const test = require('ava');
 const gzipSize = require('gzip-size');
+const prettyBytes = require('pretty-bytes');
 
 const a = fs.readFileSync('test.js', 'utf8');
 
@@ -11,9 +12,9 @@ test('file', async t => {
 	t.is(parseInt(stdout, 10), gzipSize.sync(a));
 });
 
-test('file', async t => {
-	const {stdout} = await execa('./cli.js', ['test.js', '-b']);
-	t.is(parseInt(stdout, 10), gzipSize.sync(a));
+test('pretty format', async t => {
+	const {stdout} = await execa('./cli.js', ['test.js', '--pretty']);
+	t.is(stdout, prettyBytes(gzipSize.sync(a)));
 });
 
 test('stdin', async t => {

--- a/test.js
+++ b/test.js
@@ -11,6 +11,11 @@ test('file', async t => {
 	t.is(parseInt(stdout, 10), gzipSize.sync(a));
 });
 
+test('file', async t => {
+	const {stdout} = await execa('./cli.js', ['test.js', '-b']);
+	t.is(parseInt(stdout, 10), gzipSize.sync(a));
+});
+
 test('stdin', async t => {
 	const {stdout} = await execa('./cli.js', ['test.js'], {
 		input: fs.createReadStream('test.js')

--- a/tests.js
+++ b/tests.js
@@ -1,0 +1,3 @@
+const execa = require('execa');
+
+execa('./cli.js', ['test.js', '-b']).then(console.log);

--- a/tests.js
+++ b/tests.js
@@ -1,3 +1,0 @@
-const execa = require('execa');
-
-execa('./cli.js', ['test.js', '-b']).then(console.log);


### PR DESCRIPTION
Added an optional `-b` for a more readable output without the need of piping the output through pretty-bytes. Also wrote a test for it and it passes.