### PR TITLE
Fix handling of level

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,7 +40,9 @@ if (!input && process.stdin.isTTY) {
 const source = input ? fs.createReadStream(input) : process.stdin;
 
 const options = {};
-options.level = cli.flags.level;
+if(cli.flags.level){
+	options.level = cli.flags.level;
+}
 
 source.pipe(gzipSize.stream(options)).on('gzip-size', size => {
 	console.log(cli.flags.raw ? size : prettyBytes(size));

--- a/cli.js
+++ b/cli.js
@@ -40,7 +40,7 @@ if (!input && process.stdin.isTTY) {
 const source = input ? fs.createReadStream(input) : process.stdin;
 
 const options = {};
-if(cli.flags.level){
+if (cli.flags.level) {
 	options.level = cli.flags.level;
 }
 


### PR DESCRIPTION
```
$ gzip-size package/swiper-bundle.min.js --raw
{ level: undefined } 37931
{ level: 9 } 37825
```

This happens cause `options.level` is undefined `gzip-size` cant extend it with default value here:
```js
const getOptions = options => ({level: 9, ...options});
```
https://github.com/sindresorhus/gzip-size/blob/fdb1ec139fef8fec1fb3e2c8219f1fc87b279128/index.js#L8
